### PR TITLE
Implement go to directory in terminal feature

### DIFF
--- a/app.js
+++ b/app.js
@@ -17,7 +17,7 @@ var PORT      = 1337;
 var URI_REGEX = RegExp.escape(BASE_URI) +
                 RegExp.escape(SSH_URI) +
                 '\\/([^\\/]+)' +
-                '(.*)';
+                '(.*)$';
 
 var sshport  = 22;
 var sshhosts = {
@@ -78,9 +78,9 @@ io.on('connection', function(socket) {
   process.env.LANG = 'en_US.UTF-8'; // fixes strange character issues
 
   // set up arguments for launching ssh session
-  var term_args = [sshhost, '-t', '-p', sshport];
+  var term_args = [sshhost, '-p', sshport];
   if (cwd !== null) {
-    term_args.push('cd ' + cwd + ' ; bash -l');
+    term_args.push('-t', 'cd ' + cwd + ' ; exec bash -l');
   }
 
   // launch an ssh session


### PR DESCRIPTION
Fixes #6 

A work in progress. Code can obviously be implemented cleaner.

But this is not working. I go to http://websvcs08.osc.edu:5000/pun/dev/ssh/ssh/oakley/nfs/17/efranz/ood_dev and it asks for my password. After logging in I'm at the home directory but I see this:

```
efranz@oakley.osc.edu's password:
bash: line 0: cd: /oakley/nfs/17/efranz/ood_dev: No such file or directory
efranz@oakley01:~$ pwd
/nfs/17/efranz
efranz@oakley01:~$
```

So the `(.*)` in the regex is capturing `/oakley/nfs/17/efranz/ood_dev` not `/nfs/17/efranz/ood_dev`.

But if I test this same regex using the node repel it works as expected:

```
> s = "/pun/dev/ssh/oakley/nfs/17/efranz/ood_dev"
> m = "s.match( /\/ssh\/([^\/]+)(.*)$/ )
> m[1]
'oakley'
> m[2]
'/nfs/17/efranz/ood_dev'
```
