### PR TITLE
Use HTTPS URL for install instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ This app is a Node.js app for Open OnDemand providing a web based terminal using
 1.  Clone repo to local directory
 
     ```
-    git clone git@github.com:OSC/osc-shell.git shell
+    git clone https://github.com/OSC/osc-shell.git shell
     ```
 
 2.  Due to limitations in Node.js installed through RedHat Software Collections,


### PR DESCRIPTION
The HTTPS URL is more friendly for people to clone, especially when done from an account like root.  May be worth using HTTPS URL on other repos.

```
[root@webdev02 tmp]# git clone git@github.com:OSC/osc-shell.git
Initialized empty Git repository in /tmp/osc-shell/.git/
Permission denied (publickey).
fatal: The remote end hung up unexpectedly
[root@webdev02 tmp]# git clone https://github.com/OSC/osc-shell.git
Initialized empty Git repository in /tmp/osc-shell/.git/
remote: Counting objects: 113, done.
remote: Total 113 (delta 0), reused 0 (delta 0), pack-reused 113
Receiving objects: 100% (113/113), 20.24 KiB, done.
Resolving deltas: 100% (54/54), done.
```
