### PR TITLE
Base uri fix

### DIFF
--- a/app.js
+++ b/app.js
@@ -14,7 +14,7 @@ var server   = require('socket.io');
 var pty      = require('pty.js');
 var fs       = require('fs');
 
-var BASE_URI  = require('base-uri');
+var BASE_URI = process.env.PASSENGER_BASE_URI || '/'
 var SSH_URI   = "/ssh"
 var PORT      = 1337;
 var URI_REGEX = RegExp.escape(BASE_URI) +

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -2,30 +2,6 @@
   "name": "osc-shell",
   "version": "0.0.1",
   "dependencies": {
-    "base-uri": {
-      "version": "1.1.0",
-      "from": "base-uri@>=1.0.1 <2.0.0",
-      "resolved": "https://registry.npmjs.org/base-uri/-/base-uri-1.1.0.tgz",
-      "dependencies": {
-        "url": {
-          "version": "0.10.3",
-          "from": "url@>=0.10.3 <0.11.0",
-          "resolved": "https://registry.npmjs.org/url/-/url-0.10.3.tgz",
-          "dependencies": {
-            "punycode": {
-              "version": "1.3.2",
-              "from": "punycode@1.3.2",
-              "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.3.2.tgz"
-            },
-            "querystring": {
-              "version": "0.2.0",
-              "from": "querystring@0.2.0",
-              "resolved": "https://registry.npmjs.org/querystring/-/querystring-0.2.0.tgz"
-            }
-          }
-        }
-      }
-    },
     "dotenv": {
       "version": "4.0.0",
       "from": "dotenv@>=4.0.0 <5.0.0",

--- a/package.json
+++ b/package.json
@@ -19,7 +19,6 @@
     "osc"
   ],
   "dependencies": {
-    "base-uri": "^1.0.1",
     "dotenv": "^4.0.0",
     "express-handlebars": "^3.0.0",
     "express": "^3.5.0",


### PR DESCRIPTION
Fixes #29 and gives 2 benefits to OOD development:

1. removes depencency
2. lets you run shell app without OOD install

Even if we switch to xterm.js in the future, we probably should set the SUBURI correctly.

This needs tested with OOD before pulling in (including walking through a new install - I manually edited the shrinkwrap file to avoid the annoying https://github.com/npm/npm/issues/9550).