### PR TITLE
[DO NOT MERGE] use polling instead of websockets

### DIFF
--- a/views/index.handlebars
+++ b/views/index.handlebars
@@ -21,6 +21,10 @@
       // use proper headers for xhr (doesn't work due to socket.io)
       opts.extraHeaders = {'X-Requested-With': 'XMLHttpRequest'};
 
+      // use polling for safari: omit websockets
+      // ONLY DO THIS IF YOU KNOW WEBSOCKETS WILL NOT WORK
+      opts.transports = ['polling']
+
       return _io(uri, opts);
     }
 


### PR DESCRIPTION
This branch shows how when using socket.io, you can force polling to be used as a fallback when websockets are not available. Doing this smartly could be an option for Safari users with Basic Auth i.e. https://github.com/OSC/ood-shell/issues/39.