### PR TITLE
Added option to use ssh for localhost

### DIFF
--- a/app.js
+++ b/app.js
@@ -59,7 +59,7 @@ wss.on('connection', function connection (ws) {
     if (match[2]) dir = decodeURIComponent(match[2]);
   }
 
-  if (host === 'localhost') {
+  if (host === 'localhost' && !process.env.SSH_LOCALHOST) {
     cmd = 'bash';
     args = ['-l'];
     cwd = dir ? dir : process.env.HOME;


### PR DESCRIPTION
If SSH_LOCALHOST is set, the shell will not use bash for localhost.

Feel free to make remarks (maybe using a config file instead of an environment variable)