### PR TITLE
Remove cwd arg to pty.spawn

### DIFF
--- a/app.js
+++ b/app.js
@@ -49,7 +49,7 @@ wss.on('connection', function connection (ws) {
   var host = process.env.DEFAULT_SSHHOST || 'localhost';
   var dir;
   var term;
-  var cmd, args, cwd, env;
+  var cmd, args;
 
   console.log('Connection established');
 
@@ -61,15 +61,11 @@ wss.on('connection', function connection (ws) {
 
   cmd = 'ssh';
   args = dir ? [host, '-t', 'cd \'' + dir.replace(/\'/g, "'\\''") + '\' ; exec ${SHELL} -l'] : [host];
-  cwd = process.env.HOME;
-  env = {};
-    
+
   term = pty.spawn(cmd, args, {
     name: 'xterm-256color',
     cols: 80,
-    rows: 30,
-    cwd: cwd,
-    env: env
+    rows: 30
   });
 
   console.log('Opened terminal: ' + term.pid);

--- a/app.js
+++ b/app.js
@@ -49,7 +49,7 @@ wss.on('connection', function connection (ws) {
   var host = process.env.DEFAULT_SSHHOST || 'localhost';
   var dir;
   var term;
-  var cmd, args, cwd, env, pty_spawn_env;
+  var cmd, args, cwd, env;
 
   console.log('Connection established');
 
@@ -63,20 +63,14 @@ wss.on('connection', function connection (ws) {
   args = dir ? [host, '-t', 'cd \'' + dir.replace(/\'/g, "'\\''") + '\' ; exec ${SHELL} -l'] : [host];
   cwd = process.env.HOME;
   env = {};
-
-  pty_spawn_env = {
+    
+  term = pty.spawn(cmd, args, {
     name: 'xterm-256color',
     cols: 80,
     rows: 30,
+    cwd: cwd,
     env: env
-  };
-
-  // omit cwd if ! exist, as in case of first login flow using pam_mkhomedir
-  if(fs.existsSync(cwd)){
-    pty_spawn_env.cwd = cwd;
-  }
-
-  term = pty.spawn(cmd, args, pty_spawn_env);
+  });
 
   console.log('Opened terminal: ' + term.pid);
 


### PR DESCRIPTION
And revert the fix applied on top of the cwd arg. 

these were introduced in f37f275 to support
launching bash instead of ssh using pty.spawn

since we no longer do that, just remove these extra arguments which caused
problems for cases where cwd is the home directory and the home directory
has not been created yet